### PR TITLE
use alpha version of react@16.9.0 for now. woo

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "match-sorter": "^4.0.1",
     "prop-types": "^15.7.2",
     "querystringify": "^2.1.1",
-    "react": "^16.8.6",
+    "react": "0.0.0-db3ae32b8",
     "react-async": "^7.0.5",
-    "react-dom": "^16.8.6",
+    "react-dom": "0.0.0-db3ae32b8",
     "react-icons": "^3.7.0",
     "react-scripts": "^3.0.1",
     "stop-runaway-react-effects": "^1.2.0"

--- a/src/screens/__tests__/book.js
+++ b/src/screens/__tests__/book.js
@@ -4,6 +4,7 @@ import {
   fireEvent,
   waitForElementToBeRemoved,
   within,
+  act,
 } from '@testing-library/react'
 import faker from 'faker'
 import {buildUser, buildBook, buildListItem} from '../../../test/generate'
@@ -272,7 +273,7 @@ test('can edit a note', async () => {
   // using fake timers to skip debounce time
   jest.useFakeTimers()
   fireEvent.change(notesTextarea, {target: {value: newNotes}})
-  jest.runAllTimers()
+  act(() => jest.runAllTimers())
   jest.useRealTimers()
 
   await waitForElementToBeRemoved(() => getByLabelText(/loading/i))
@@ -301,7 +302,7 @@ test('note update failures are displayed', async () => {
   // using fake timers to skip debounce time
   jest.useFakeTimers()
   fireEvent.change(notesTextarea, {target: {value: newNotes}})
-  jest.runAllTimers()
+  act(() => jest.runAllTimers())
   jest.useRealTimers()
 
   await waitForElementToBeRemoved(() => getByLabelText(/loading/i))

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -12,19 +12,3 @@ beforeEach(() => {
 afterEach(() => {
   window.fetch.mockRestore()
 })
-
-// this is just a little hack to silence a warning that we'll get until react
-// fixes this: https://github.com/facebook/react/pull/14853
-const originalError = console.error
-beforeAll(() => {
-  console.error = (...args) => {
-    if (/Warning.*not wrapped in act/.test(args[0])) {
-      return
-    }
-    originalError.call(console, ...args)
-  }
-})
-
-afterAll(() => {
-  console.error = originalError
-})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8373,15 +8373,15 @@ react-dev-utils@^9.0.1:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dom@^16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
-  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+react-dom@0.0.0-db3ae32b8:
+  version "0.0.0-db3ae32b8"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-db3ae32b8.tgz#962fe9d4f22da52f43d6642bedf1a2cca35fc9e3"
+  integrity sha512-pxBbQmtC5CxHl2MbNqatyWteso1L8liBypzWBoCD/eHotSQBj83YSpblT5sDASRv3sztGEiu3zHZ5Eay/4tRXw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.6"
+    scheduler "0.0.0-db3ae32b8"
 
 react-error-overlay@^5.1.6:
   version "5.1.6"
@@ -8499,15 +8499,14 @@ react-style-singleton@^1.1.0:
     invariant "^2.2.4"
     tslib "^1.0.0"
 
-react@^16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
-  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
+react@0.0.0-db3ae32b8:
+  version "0.0.0-db3ae32b8"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-db3ae32b8.tgz#71a8adcd8011d955025ec00788d640d8a6606bfe"
+  integrity sha512-yIEBDCfszi7OmyRLXbY1XCMjIxLNuUYjCRzfaVp3hb2ExZKwIuDyaLiF5Dv++OsoCs4780DIQPz+pEYW9Ii1sQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.6"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -8956,10 +8955,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scheduler@^0.13.6:
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
-  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+scheduler@0.0.0-db3ae32b8:
+  version "0.0.0-db3ae32b8"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-db3ae32b8.tgz#3480f06fe5418dab594ad4cc36d61ebed45b70fb"
+  integrity sha512-/mNl10fb9X637CLEV3m0W4pbb8SVfG0nKuU0lNhIgMLJaeqlk1u2L57C786DFv8QgPkiKI/CZIlQRGcBa2IGoA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
This PR demonstrates the updates I needed to make to account for the upcoming changes in react@16.9.0.

Based on my testing here and in other projects, there are only 2 places where people will need to use `act` if they're using RTL's utilities:

1. If they use Jest's fake timers
2. If they're testing custom hooks

With normal component tests, RTL's utilities will handle calling `act` :)