### PR TITLE
remove variable listItemIds was declared but never referenced

### DIFF
--- a/src/utils/list-items-client.js
+++ b/src/utils/list-items-client.js
@@ -4,7 +4,7 @@ function create(listItemData) {
   return client('list-items', {body: listItemData})
 }
 
-function read(listItemIds = []) {
+function read() {
   return client('list-items')
 }
 


### PR DESCRIPTION
small correction, remove variable listItemIds was declared but never referenced.

If this PR is accepted, we have to fix it on the blog:
https://kentcdodds.com/blog/replace-axios-with-a-simple-custom-fetch-wrapper