### PR TITLE
Updates "msw" package to 0.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11967,13 +11967,13 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msw": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.14.1.tgz",
-      "integrity": "sha512-xkicTH+hpt3JC5sGZhXBXPdPhOh0n5Qs2YDSMw4n93qOGIQwxAriek1OmBET8vriCSdi1Pt1uyFBJI0pGNxZ1Q==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.15.2.tgz",
+      "integrity": "sha512-ubbjlO1JxxL0+pBkvGG424+HhnDfkaLO/PVSkYwbjz4SO8u7yF/7MBDvLSAuMomnbxIa+Buu8wi744olDXCFJQ==",
       "requires": {
         "@open-draft/until": "^1.0.0",
         "chalk": "^4.0.0",
-        "cookie": "^0.4.0",
+        "cookie": "^0.4.1",
         "graphql": "^15.0.0",
         "node-match-path": "^0.4.2",
         "statuses": "^2.0.0",
@@ -12010,6 +12010,11 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
         },
         "has-flag": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "faker": "^4.1.0",
     "history": "^5.0.0-beta.5",
     "match-sorter": "^4.1.0",
-    "msw": "^0.14.1",
+    "msw": "^0.15.2",
     "node-match-path": "^0.4.2",
     "prop-types": "^15.7.2",
     "react": "16.13.1",

--- a/src/test/server.js
+++ b/src/test/server.js
@@ -1,4 +1,4 @@
-import {composeMocks} from 'msw'
+import {setupWorker} from 'msw'
 import {handlers} from './server-handlers'
 import {homepage} from '../../package.json'
 
@@ -16,7 +16,7 @@ async function startServer() {
     }
     throw new Error('This app requires service worker support (over HTTPS).')
   }
-  await composeMocks(...handlers).start({
+  await setupWorker(...handlers).start({
     quiet: true,
     serviceWorker: {
       url: fullUrl.pathname + 'mockServiceWorker.js',


### PR DESCRIPTION
## Changes

- Updates `msw` to `0.15.2` to contain the fix for hard reload issue with multiple clients (https://github.com/open-draft/msw/issues/122).
- Replaces calls to a deprecated `composeMocks()` with `setupWorker()` to be prepared for the future releases.


## Manual testing preview

![bookshelf-hard-reload](https://user-images.githubusercontent.com/14984911/80688159-acc7f080-8acb-11ea-8250-238d9a87c4de.gif)
