### PR TITLE
Updates "msw" to 0.15.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11984,9 +11984,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msw": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.15.4.tgz",
-      "integrity": "sha512-h1OaVi6BiSTGBxyMCeDQ/Rs4179P+lHD+lRkUXLdHrMSNf3a30hf7mYuOvLpOi2EH/bCIkYsnx+hknqzjfFbeQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.15.6.tgz",
+      "integrity": "sha512-9L8IEQlCZn4g3lZrS+RNxLKsHHvhQ607SHgAWs+wMw56I2F+zuUb9+k0Bx+hq+VlAFAPMlH8o+CYzqKA4GSJ3A==",
       "requires": {
         "@open-draft/until": "^1.0.0",
         "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "faker": "^4.1.0",
     "history": "^5.0.0-beta.5",
     "match-sorter": "^4.1.0",
-    "msw": "^0.15.4",
+    "msw": "^0.15.6",
     "node-match-path": "^0.4.2",
     "prop-types": "^15.7.2",
     "react": "16.13.1",


### PR DESCRIPTION
## Changes

- Updates `msw` to [`0.15.6`](https://github.com/mswjs/msw/releases/tag/v0.15.6) to fix the negative lookbehind issue.

## GitHub

- Fixes #46