### PR TITLE
Uses built-in JSON body parsing from "msw"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11514,9 +11514,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msw": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.16.1.tgz",
-      "integrity": "sha512-G51jrA/wDoYBobeXXID7Av9S6hpdHB4uIbVq+MALeG/qIV4JSJcZM6wmZhTrtWWGxZPDWvC47V+p4ycYZ1MnQw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.16.2.tgz",
+      "integrity": "sha512-Iu1pLNfUNzKijSUaHiHZy+JFvBzStSC+K21FU0KpqUVGgUKQ+zy31fcG/U1pAYEByF40WPXevagnKwO/mNlvJg==",
       "requires": {
         "@open-draft/until": "^1.0.0",
         "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "faker": "^4.1.0",
     "history": "^5.0.0-beta.5",
     "match-sorter": "^4.1.0",
-    "msw": "^0.16.1",
+    "msw": "^0.16.2",
     "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/src/test/server-handlers.js
+++ b/src/test/server-handlers.js
@@ -124,13 +124,6 @@ const handlers = [
     ...handler,
     async resolver(req, res, ctx) {
       try {
-        try {
-          req.body =
-            typeof req.body === 'string' ? JSON.parse(req.body) : req.body
-        } catch (error) {
-          // https://github.com/kentcdodds/bookshelf/pull/57#issuecomment-631094130
-          // ignore the error
-        }
         const result = await handler.resolver(req, res, ctx)
         if (shouldFail(req)) {
           throw new Error('Random failure (for testing purposes). Try again.')


### PR DESCRIPTION
## Changes 

- Updates to `msw@0.16.2`
- Removes the `try/catch` block around `req.body` parsing. Uses a built-in JSON body parsing from `msw`, whenever `Content-Type` includes "json".

## GitHub

- Follow up to #57