### PR TITLE
Msw warn on unhandled

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -22,7 +22,7 @@ process.env.DEBUG_PRINT_LIMIT = 15000
 
 // enable API mocking in test runs using the same request handlers
 // as for the client-side mocking.
-beforeAll(() => server.listen())
+beforeAll(() => server.listen({onUnhandledRequest: 'error'}))
 afterAll(() => server.close())
 afterEach(() => server.resetHandlers())
 


### PR DESCRIPTION
## Changes

- Configures `server.listen()` call to warn on unhandled requests during tests.