### PR TITLE
moved from bash to nodejs fs commands

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -69,7 +69,7 @@ function getVariants() {
 
 function getExerciseBranches() {
   const branches = spawnSync(
-    `git for-each-ref --format='%(refname:short)'`,
+    `git for-each-ref --format="%(refname:short)"`,
   ).split('\n')
   return branches.filter(b => b.startsWith('exercises/'))
 }


### PR DESCRIPTION
This fixes issues with windows:
- `node go` command now working properly (closes #78 )
- `npm run validate` now working in exercise branches

Moved from bash commands (`rm`, `mkdir` and `mv`) to nodejs fs equivalents:
- [`fs.mkdirSync`](https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options) added with recursive option in node `v10.12.0`
- [`fs.rmdirSync`](https://nodejs.org/api/fs.html#fs_fs_rmdirsync_path_options) added with recursive option in node `v12.10.0`
- [`fs.renameSync`](https://nodejs.org/api/fs.html#fs_fs_renamesync_oldpath_newpath) and [`fs.existsSync`](https://nodejs.org/api/fs.html#fs_fs_existssync_path) added much earlier