### PR TITLE
test(rating): add unit test for rating component

### DIFF
--- a/src/components/__tests__/rating.js
+++ b/src/components/__tests__/rating.js
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 import {buildBook, buildListItem} from 'test/generate'
 import * as booksDB from 'test/data/books'
 import * as listItemsDB from 'test/data/list-items'
-import {Rating} from '../Rating'
+import {Rating} from '../rating'
 
 async function renderRating({rating = 0} = {}) {
   const book = await booksDB.create(buildBook())

--- a/src/components/__tests__/rating.js
+++ b/src/components/__tests__/rating.js
@@ -23,10 +23,10 @@ test('it updates the rating', async () => {
 
   userEvent.click(firstStar)
 
-  let updatedListItem
-  do {
-    updatedListItem = await listItemsDB.read(listItem.id)
-  } while (updatedListItem.rating !== 1)
+  await waitFor(async () => {
+    const updatedListItem = await listItemsDB.read(listItem.id)
+    expect(updatedListItem.rating).toBe(1)
+  })
 })
 
 test(`it shows the correct rating for 0 stars`, async () => {

--- a/src/components/__tests__/rating.js
+++ b/src/components/__tests__/rating.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {render, screen, loginAsUser} from 'test/app-test-utils'
+import {render, screen, waitFor, loginAsUser} from 'test/app-test-utils'
 import userEvent from '@testing-library/user-event'
 import {buildBook, buildListItem} from 'test/generate'
 import * as booksDB from 'test/data/books'

--- a/src/components/__tests__/rating.js
+++ b/src/components/__tests__/rating.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import {render, screen, loginAsUser, act, waitFor} from 'test/app-test-utils'
+import userEvent from '@testing-library/user-event'
+import {buildBook, buildListItem} from 'test/generate'
+import * as booksDB from 'test/data/books'
+import * as listItemsDB from 'test/data/list-items'
+import {Rating} from '../Rating'
+
+async function renderRating({rating = 0} = {}) {
+  const book = await booksDB.create(buildBook())
+  const user = await loginAsUser()
+  const listItem = await listItemsDB.create({
+    ...buildListItem({owner: user, book}),
+    rating,
+  })
+  const utils = await render(<Rating listItem={listItem} />, {user})
+  return {...utils, book, user, listItem}
+}
+
+test('it updates the rating', async () => {
+  const {listItem, rerender} = await renderRating()
+  const firstStar = screen.getByLabelText('1 star')
+
+  userEvent.click(firstStar)
+
+  // needed because of react-query
+  await waitFor(() => {})
+  const updatedListItem = await listItemsDB.read(listItem.id)
+  rerender(<Rating listItem={updatedListItem} />)
+  expect(screen.getByLabelText('1 star')).toBeChecked()
+})

--- a/src/components/__tests__/rating.js
+++ b/src/components/__tests__/rating.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {render, screen, loginAsUser, waitFor} from 'test/app-test-utils'
+import {render, screen, loginAsUser} from 'test/app-test-utils'
 import userEvent from '@testing-library/user-event'
 import {buildBook, buildListItem} from 'test/generate'
 import * as booksDB from 'test/data/books'
@@ -23,9 +23,11 @@ test('it updates the rating', async () => {
 
   userEvent.click(firstStar)
 
-  expect(screen.getByLabelText('1 star')).toBeChecked()
   let updatedListItem
   do {
     updatedListItem = await listItemsDB.read(listItem.id)
-  } while (updateListItem.rating !== 1)
+  } while (updatedListItem.rating !== 1)
+
+  rerender(<Rating listItem={updatedListItem} />)
+  expect(screen.getByLabelText('1 star')).toBeChecked()
 })

--- a/src/components/__tests__/rating.js
+++ b/src/components/__tests__/rating.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {render, screen, loginAsUser, act, waitFor} from 'test/app-test-utils'
+import {render, screen, loginAsUser, waitFor} from 'test/app-test-utils'
 import userEvent from '@testing-library/user-event'
 import {buildBook, buildListItem} from 'test/generate'
 import * as booksDB from 'test/data/books'

--- a/src/components/__tests__/rating.js
+++ b/src/components/__tests__/rating.js
@@ -18,7 +18,7 @@ async function renderRating({rating = 0} = {}) {
 }
 
 test('it updates the rating', async () => {
-  const {listItem, rerender} = await renderRating()
+  const {listItem} = await renderRating()
   const firstStar = screen.getByLabelText('1 star')
 
   userEvent.click(firstStar)
@@ -27,7 +27,30 @@ test('it updates the rating', async () => {
   do {
     updatedListItem = await listItemsDB.read(listItem.id)
   } while (updatedListItem.rating !== 1)
-
-  rerender(<Rating listItem={updatedListItem} />)
-  expect(screen.getByLabelText('1 star')).toBeChecked()
 })
+
+test(`it shows the correct rating for 0 stars`, async () => {
+  await renderRating()
+
+  expect(screen.getByLabelText('1 star')).not.toBeChecked()
+  expect(screen.getByLabelText('2 stars')).not.toBeChecked()
+  expect(screen.getByLabelText('3 stars')).not.toBeChecked()
+  expect(screen.getByLabelText('4 stars')).not.toBeChecked()
+  expect(screen.getByLabelText('5 stars')).not.toBeChecked()
+})
+
+test.each`
+  rating | selectedLabel
+  ${1}   | ${'1 star'}
+  ${2}   | ${'2 stars'}
+  ${3}   | ${'3 stars'}
+  ${4}   | ${'4 stars'}
+  ${5}   | ${'5 stars'}
+`(
+  `it shows the correct rating for $selectedLabel`,
+  async ({rating, selectedLabel}) => {
+    await renderRating({rating})
+
+    expect(screen.getByLabelText(selectedLabel)).toBeChecked()
+  },
+)

--- a/src/components/__tests__/rating.js
+++ b/src/components/__tests__/rating.js
@@ -23,9 +23,9 @@ test('it updates the rating', async () => {
 
   userEvent.click(firstStar)
 
-  // needed because of react-query
-  await waitFor(() => {})
-  const updatedListItem = await listItemsDB.read(listItem.id)
-  rerender(<Rating listItem={updatedListItem} />)
   expect(screen.getByLabelText('1 star')).toBeChecked()
+  let updatedListItem
+  do {
+    updatedListItem = await listItemsDB.read(listItem.id)
+  } while (updateListItem.rating !== 1)
 })


### PR DESCRIPTION
Adding tests for the rating component. You mentioned on the last livestream that this would be welcome so I took a stab at it.

There's a couple of findings on this test that caught me off guard and I'd be more than happy to hear what y'all think of it.

1. I was forced into using an empty `waitFor` on line 27 for `react-query` to catch up and perform the update on the database. I feel like it's a similar issue that's mentioned on the `setupTests` file.
2. Because the component receives the `listItem` through props and doesn't read it from the database, I had to rerender it with the updated list item from the database. If we passed just the `bookId` and then make use of `useListItem` to read from the db than this would not be needed. I experimented with and it's a rather simple change. I just choose not to because it'd also change the component API.