### PR TITLE
Fix `queryCache.setQueryData` arguments

### DIFF
--- a/src/utils/books.exercise.js
+++ b/src/utils/books.exercise.js
@@ -72,11 +72,7 @@ const bookQueryConfig = {
 }
 
 function setQueryDataForBook(book) {
-  queryCache.setQueryData({
-    queryKey: ['book', {bookId: book.id}],
-    queryFn: book,
-    ...bookQueryConfig,
-  })
+  queryCache.setQueryData(['book', {bookId: book.id}], book, bookQueryConfig)
 }
 
 export {useBook, useBookSearch, refetchBookSearchQuery, setQueryDataForBook}

--- a/src/utils/books.extra-1.js
+++ b/src/utils/books.extra-1.js
@@ -66,11 +66,7 @@ const bookQueryConfig = {
 }
 
 function setQueryDataForBook(book) {
-  queryCache.setQueryData({
-    queryKey: ['book', {bookId: book.id}],
-    queryFn: book,
-    ...bookQueryConfig,
-  })
+  queryCache.setQueryData(['book', {bookId: book.id}], book, bookQueryConfig)
 }
 
 export {useBook, useBookSearch, useRefetchBookSearchQuery, setQueryDataForBook}

--- a/src/utils/books.extra-4.js
+++ b/src/utils/books.extra-4.js
@@ -62,11 +62,7 @@ const bookQueryConfig = {
 }
 
 function setQueryDataForBook(book) {
-  queryCache.setQueryData({
-    queryKey: ['book', {bookId: book.id}],
-    queryFn: book,
-    ...bookQueryConfig,
-  })
+  queryCache.setQueryData(['book', {bookId: book.id}], book, bookQueryConfig)
 }
 
 export {useBook, useBookSearch, useRefetchBookSearchQuery, setQueryDataForBook}

--- a/src/utils/books.final.js
+++ b/src/utils/books.final.js
@@ -66,11 +66,7 @@ const bookQueryConfig = {
 }
 
 function setQueryDataForBook(book) {
-  queryCache.setQueryData({
-    queryKey: ['book', {bookId: book.id}],
-    queryFn: book,
-    ...bookQueryConfig,
-  })
+  queryCache.setQueryData(['book', {bookId: book.id}], book, bookQueryConfig)
 }
 
 export {useBook, useBookSearch, useRefetchBookSearchQuery, setQueryDataForBook}


### PR DESCRIPTION
Hi! I noticed that there is a bug caused by incorrect arguments passed to `queryCache.setQueryData` from `react-query`. Because of that cache is not set correctly and books data is not read from cache like in exercise 6.  This bug is also present in exercises from 8 to 14 but I don't know how to change multiple branches in a single PR. Do you know if I can do that? Or should I create separate PR for every exercise?

PS. Thank you so much for creating Epic React!