### PR TITLE
Use is-ci-cli binary instead of is-ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "start": "react-scripts start",
     "start:cli": "cross-env BROWSER=none react-scripts start",
     "build": "react-scripts build --profile",
-    "test": "is-ci \"test:coverage\" \"test:watch\"",
+    "test": "is-ci-cli \"test:coverage\" \"test:watch\"",
     "test:watch": "jest --watch",
     "test:coverage": "jest --watch=false --coverage",
     "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --watch --runInBand",


### PR DESCRIPTION
Running `npm run test` on my machine returns with the exit code 1 where `CI=true npm run test` returns with a exit code 0. It will not execute either `npm run test:watch` nor `npm run test:coverage`.

I noticed that his is due to a conflict between the binaries of [`is-ci`](https://github.com/watson/is-ci) and [`is-ci-cli`](https://github.com/YellowKirby/is-ci-cli). Both of them are registering the binary `is-ci` but they are behaving differently. The `is-ci-cli` package added a command `is-ci-cli` to fix this.

[See this issue for more details.](https://github.com/YellowKirby/is-ci-cli/issues/13)

Based on the description of the issue this is happening on `npm@7` due to a change in the handling of binary conflicts.

Unfortunately I cannot validate if any videos would need to change as I am only going through the bookshelf repository without having the course.