### PR TITLE
docs: fix broken egghead course link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,5 +53,5 @@ Also, please watch the repo and respond to questions/bug reports/feature
 requests! Thanks!
 
 [egghead]:
-  https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+  https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://github.com/kentcdodds/bookshelf/issues


### PR DESCRIPTION
Hello,
I notice that the egghead link to the course "How to Contribute to an Open Source Project on GitHub" lead to a 404.
Iacopo