### PR TITLE
Remove v17 from node.js requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ## System Requirements
 
 - [git][git] v2.13 or greater
-- [NodeJS][node] `12 || 14 || 15 || 16 || 17`
+- [NodeJS][node] `12 || 14 || 15 || 16`
 - [npm][npm] v6 or greater
 
 All of these must be available in your `PATH`. To verify things are set up


### PR DESCRIPTION
As per this change https://github.com/kentcdodds/bookshelf/commit/0ad2e1fb5636795343e66f4c3c5279b465a88186 Nodejs 17 is not supported.
This change updates the readme to remove Nodejs 17 under system requirements.