### PR TITLE
fix: revert jest-watch-typeahead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1826,15 +1826,6 @@
         }
       }
     },
-    "@jest/schemas": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
-      "integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
-      "dev": true,
-      "requires": {
-        "@sinclair/typebox": "^0.23.3"
-      }
-    },
     "@jest/source-map": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.6.2.tgz",
@@ -2352,12 +2343,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "dev": true
-    },
-    "@sinclair/typebox": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.4.tgz",
-      "integrity": "sha512-0/WqSvpVbCBAV1yPeko7eAczKbs78dNVAaX14quVlwOb2wxfKuXCx91h4NrEfkYK9zEnyVSW4JVI/trP3iS+Qg==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -11363,72 +11348,63 @@
       }
     },
     "jest-watch-typeahead": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-1.1.0.tgz",
-      "integrity": "sha512-Va5nLSJTN7YFtC2jd+7wsoe1pNe5K4ShLux/E5iHEwlB9AxaxmggY7to9KUqKojhaJw3aXqt5WAb4jGPOolpEw==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-0.6.4.tgz",
+      "integrity": "sha512-tGxriteVJqonyrDj/xZHa0E2glKMiglMLQqISLCjxLUfeueRBh9VoRF2FKQyYO2xOqrWDTg7781zUejx411ZXA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.3.1",
         "chalk": "^4.0.0",
-        "jest-regex-util": "^28.0.0",
-        "jest-watcher": "^28.0.0",
-        "slash": "^4.0.0",
-        "string-length": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "jest-regex-util": "^27.0.0",
+        "jest-watcher": "^27.0.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "@jest/console": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/console/-/console-28.0.2.tgz",
-          "integrity": "sha512-tiRpnMeeyQuuzgL5UNSeiqMwF8UOWPbAE5rzcu/1zyq4oPG2Ox6xm4YCOruwbp10F8odWc+XwVxTyGzMSLMqxA==",
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.5.1.tgz",
+          "integrity": "sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^28.0.2",
+            "@jest/types": "^27.5.1",
             "@types/node": "*",
             "chalk": "^4.0.0",
-            "jest-message-util": "^28.0.2",
-            "jest-util": "^28.0.2",
+            "jest-message-util": "^27.5.1",
+            "jest-util": "^27.5.1",
             "slash": "^3.0.0"
-          },
-          "dependencies": {
-            "slash": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-              "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-              "dev": true
-            }
           }
         },
         "@jest/test-result": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-28.0.2.tgz",
-          "integrity": "sha512-4EUqgjq9VzyUiVTvZfI9IRJD6t3NYBNP4f+Eq8Zr93+hkJ0RrGU4OBTw8tfNzidKX+bmuYzn8FxqpxOPIGGCMA==",
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.5.1.tgz",
+          "integrity": "sha512-EW35l2RYFUcUQxFJz5Cv5MTOxlJIQs4I7gxzi2zVU7PJhOwfYq1MdC5nhSmYjX1gmMmLPvB3sIaC+BkcHRBfag==",
           "dev": true,
           "requires": {
-            "@jest/console": "^28.0.2",
-            "@jest/types": "^28.0.2",
+            "@jest/console": "^27.5.1",
+            "@jest/types": "^27.5.1",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "collect-v8-coverage": "^1.0.0"
           }
         },
         "@jest/types": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
-          "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+          "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^28.0.2",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^17.0.8",
+            "@types/yargs": "^16.0.0",
             "chalk": "^4.0.0"
           }
         },
         "@types/yargs": {
-          "version": "17.0.10",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
-          "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+          "version": "16.0.4",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -11474,12 +11450,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "emittery": {
-          "version": "0.10.2",
-          "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
-          "integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -11487,43 +11457,35 @@
           "dev": true
         },
         "jest-message-util": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.0.2.tgz",
-          "integrity": "sha512-knK7XyojvwYh1XiF2wmVdskgM/uN11KsjcEWWHfnMZNEdwXCrqB4sCBO94F4cfiAwCS8WFV6CDixDwPlMh/wdA==",
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
+          "integrity": "sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^28.0.2",
+            "@jest/types": "^27.5.1",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.9",
             "micromatch": "^4.0.4",
-            "pretty-format": "^28.0.2",
+            "pretty-format": "^27.5.1",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
-          },
-          "dependencies": {
-            "slash": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-              "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-              "dev": true
-            }
           }
         },
         "jest-regex-util": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
-          "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
+          "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
           "dev": true
         },
         "jest-util": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
-          "integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
+          "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
           "dev": true,
           "requires": {
-            "@jest/types": "^28.0.2",
+            "@jest/types": "^27.5.1",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "ci-info": "^3.2.0",
@@ -11532,52 +11494,29 @@
           }
         },
         "jest-watcher": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.0.2.tgz",
-          "integrity": "sha512-uIVJLpQ/5VTGQWBiBatHsi7jrCqHjHl0e0dFHMWzwuIfUbdW/muk0DtSr0fteY2T7QTFylv+7a5Rm8sBKrE12Q==",
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.5.1.tgz",
+          "integrity": "sha512-z676SuD6Z8o8qbmEGhoEUFOM1+jfEiL3DXHK/xgEiG2EyNYfFG60jluWcupY6dATjfEsKQuibReS1djInQnoVw==",
           "dev": true,
           "requires": {
-            "@jest/test-result": "^28.0.2",
-            "@jest/types": "^28.0.2",
+            "@jest/test-result": "^27.5.1",
+            "@jest/types": "^27.5.1",
             "@types/node": "*",
             "ansi-escapes": "^4.2.1",
             "chalk": "^4.0.0",
-            "emittery": "^0.10.2",
-            "jest-util": "^28.0.2",
+            "jest-util": "^27.5.1",
             "string-length": "^4.0.1"
-          },
-          "dependencies": {
-            "string-length": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-              "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-              "dev": true,
-              "requires": {
-                "char-regex": "^1.0.2",
-                "strip-ansi": "^6.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            }
           }
         },
         "pretty-format": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
-          "integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^28.0.2",
             "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
+            "react-is": "^17.0.1"
           },
           "dependencies": {
             "ansi-styles": {
@@ -11589,51 +11528,10 @@
           }
         },
         "react-is": {
-          "version": "18.1.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
-          "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
           "dev": true
-        },
-        "slash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-          "dev": true
-        },
-        "string-length": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
-          "integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
-          "dev": true,
-          "requires": {
-            "char-regex": "^2.0.0",
-            "strip-ansi": "^7.0.1"
-          },
-          "dependencies": {
-            "char-regex": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.1.tgz",
-              "integrity": "sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==",
-              "dev": true
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-              "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-              "dev": true
-            }
-          }
         },
         "supports-color": {
           "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "is-ci": "^3.0.1",
     "is-ci-cli": "^2.2.0",
     "jest": "^26.6.3",
-    "jest-watch-typeahead": "^1.1.0",
+    "jest-watch-typeahead": "^0.6.4",
     "node-match-path": "^0.6.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",


### PR DESCRIPTION
In a [recent commit](https://github.com/kentcdodds/bookshelf/commit/659a6cd159385a9f984981b8ef80298299958d5e), you updated many dependencies including `jest-watch-typeahead@1` which [does not support jest@26](https://github.com/jest-community/jest-watch-typeahead/issues/99#issuecomment-977716742)

## Attempted solutions 

Upgrading to jest@27 returned error on test: internet solutions are always to upgrade Jest to solve, possibly a version+config mismatch?
```
TypeError: Cannot destructure property 'config' of 'options' as it is undefined
```


Upgrading to jest@28 returned error on test: internet says Jest's origin URL must be set in jest.config explicitly in order to access the localStorage API. Attempting to add this (even hardcoded to localhost) did not solve this

```
SecurityError: localStorage is not available for opaque origins
```

## Conclusion 

After those two attempts I tried reverting jest-watch-typeahead to the version it was prior to your deps update and all the tests run and pass successfully now.

I uncovered this while running through the start of the module in Gitpod, and I can confirm that after reverting it the tests function correctly again.